### PR TITLE
Add measure function that uses probabilities function

### DIFF
--- a/gates.py
+++ b/gates.py
@@ -1,8 +1,6 @@
 
 import numpy as np
 
-from qubit import Qubits
-
 
 class Gate(object):
     """Gate represent a Quantum gate.
@@ -18,14 +16,33 @@ class Gate(object):
         self.name = name
         self.matrix = matrix
 
-    def __mul__(self, gate):
-        assert isinstance(gate, Gate)
-        return Gate('Custom', np.kron(self.matrix, gate.matrix))
+    def __mul__(self, b):
+        if isinstance(b, int):
+            return Gate('Custom', b*self.matrix)
+
+        if isinstance(b, Gate):
+            return Gate('Custom', np.kron(self.matrix, b.matrix))
+
+        raise TypeError("Gate * %s not supported" % type(b))
+
+    def __rmul__(self, b):
+        return self.__mul__(b)
+
+
+    def __pow__(self, n):
+        if n == 0:
+            return 1
+
+        elif n == 1:
+            return self
+
+        elif n > 1:
+            return self * (self ** (n-1))
+
+        raise AssertionError("Gate ** %d not supported" % n)
 
     def __or__(self, qubits):
         """Apply gate on `qubits`."""
-        assert isinstance(qubits, Qubits), (
-            "A gate can only be applied on a Qubits object")
         qubits.state = self.matrix * qubits.state
 
     def __str__(self):
@@ -38,10 +55,8 @@ Hadamard = Gate('Hadamard',
 Identity = Gate('Identity',
                np.matrix([[1.0, 0.0], [0.0, 1.0]], dtype=np.complex256))
 
-# TODO: Verify this is true
 ToZero = Gate('ZeroProjection',
-               np.matrix([[1.0, 1.0], [0.0, 0.0]], dtype=np.complex256))
+               np.matrix([[1.0, 0.0], [0.0, 0.0]], dtype=np.complex256))
 
-# TODO: Verify this is true
 ToOne = Gate('OneProjection',
-             np.matrix([[0.0, 0.0], [1.0, 1.0]], dtype=np.complex256))
+             np.matrix([[0.0, 0.0], [0.0, 1.0]], dtype=np.complex256))

--- a/gates.py
+++ b/gates.py
@@ -37,3 +37,11 @@ Hadamard = Gate('Hadamard',
                           dtype=np.complex256) / np.sqrt(2))
 Identity = Gate('Identity',
                np.matrix([[1.0, 0.0], [0.0, 1.0]], dtype=np.complex256))
+
+# TODO: Verify this is true
+ToZero = Gate('ZeroProjection',
+               np.matrix([[1.0, 1.0], [0.0, 0.0]], dtype=np.complex256))
+
+# TODO: Verify this is true
+ToOne = Gate('OneProjection',
+             np.matrix([[0.0, 0.0], [1.0, 1.0]], dtype=np.complex256))

--- a/gates.py
+++ b/gates.py
@@ -43,7 +43,7 @@ class Gate(object):
 
     def __or__(self, qubits):
         """Apply gate on `qubits`."""
-        qubits.state = self.matrix * qubits.state
+        qubits.state = np.asarray(self.matrix * qubits.state)
 
     def __str__(self):
         return self.name

--- a/measure.py
+++ b/measure.py
@@ -10,8 +10,8 @@ def get_bit(i, k, n):
 
 def measure(qubits, i):
     """Measure qubit `i` in `qubits` and return 0 or 1. Index `i` from 0."""
-    assert i < 2**qubits.n, (
-        "qubit %d can not be measured in %d-qubit state" % (i, self.n))
+    assert i < qubits.n, (
+        "qubit %d can not be measured in %d-qubit state" % (i, qubits.n))
     distribution = qubits.distribution()
     p = np.squeeze(np.asarray(distribution, dtype=np.float64))
     index = np.random.choice(np.arange(2**qubits.n), p=p)

--- a/measure.py
+++ b/measure.py
@@ -4,9 +4,9 @@ import numpy as np
 from gates import ToZero, ToOne, Identity
 
 
-def get_bit(i, k):
-    """Return value of bit `i` for state at index `k`."""
-    return (k >> i) & 0x1
+def get_bit(i, k, n):
+    """Return value of bit `i` for `n` qubit state `k`."""
+    return (k >> (n-1-i)) & 0x1
 
 def measure(qubits, i):
     """Measure qubit `i` in `qubits` and return 0 or 1. Index `i` from 0."""
@@ -15,7 +15,7 @@ def measure(qubits, i):
     distribution = qubits.distribution()
     p = np.squeeze(np.asarray(distribution, dtype=np.float64))
     index = np.random.choice(np.arange(2**qubits.n), p=p)
-    result = get_bit(i, index)
+    result = get_bit(i, index, qubits.n)
     projection = ToZero if result == 0 else ToOne
     transform = (Identity ** i) * projection * (Identity ** (qubits.n-i-1))
     transform | qubits

--- a/measure.py
+++ b/measure.py
@@ -1,0 +1,21 @@
+
+from gates import ToZero, ToOne, Identity
+
+
+def get_bit(self, i, k):
+    """Return value of bit `i` for state at index `k`."""
+    return (index >> i) & 0x1
+
+def measure(qubits, i):
+    """Measure qubit `i` in `qubits` and return 0 or 1. Index `i` from 0."""
+    assert i < self.n, (
+        "qubit %d can not be measured in %d-qubit state" % (i, self.n))
+    distribution = qubits.distribution()
+    index = np.random.choice(np.arange(2**qubits.n), p=distribution)
+    result = get_bit(i, index)
+    projection = ToZero if result == 0 else ToOne
+    transform = (Identity ** i) * projection * (Identity ** (n-i-1))
+    transform | qubits
+    qubits.normalize()
+
+    return result

--- a/measure.py
+++ b/measure.py
@@ -1,20 +1,23 @@
 
+import numpy as np
+
 from gates import ToZero, ToOne, Identity
 
 
-def get_bit(self, i, k):
+def get_bit(i, k):
     """Return value of bit `i` for state at index `k`."""
-    return (index >> i) & 0x1
+    return (k >> i) & 0x1
 
 def measure(qubits, i):
     """Measure qubit `i` in `qubits` and return 0 or 1. Index `i` from 0."""
-    assert i < self.n, (
+    assert i < 2**qubits.n, (
         "qubit %d can not be measured in %d-qubit state" % (i, self.n))
     distribution = qubits.distribution()
-    index = np.random.choice(np.arange(2**qubits.n), p=distribution)
+    p = np.squeeze(np.asarray(distribution, dtype=np.float64))
+    index = np.random.choice(np.arange(2**qubits.n), p=p)
     result = get_bit(i, index)
     projection = ToZero if result == 0 else ToOne
-    transform = (Identity ** i) * projection * (Identity ** (n-i-1))
+    transform = (Identity ** i) * projection * (Identity ** (qubits.n-i-1))
     transform | qubits
     qubits.normalize()
 

--- a/qubit.py
+++ b/qubit.py
@@ -30,7 +30,7 @@ class Qubits(object):
         return 'Qubits(%d)' % self.n
 
     def normalize(self):
-        print "normalize not implemented yet"
+        self.state = self.state / np.linalg.norm(self.state)
 
     def distribution(self):
         """

--- a/qubit.py
+++ b/qubit.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-
+from gates import ToZero, ToOne, Identity
 
 class Qubits(object):
 
@@ -36,6 +36,7 @@ class Qubits(object):
         The position of the list indicates the corresponding state.
         """
         return np.real(np.multiply(self.state, np.conjugate(self.state)))
+
 
 Zero = Qubits(state=np.array([[1.0], [0.0]], dtype=np.complex256))
 One = Qubits(state=np.array([[0.0], [1.0]], dtype=np.complex256))

--- a/qubit.py
+++ b/qubit.py
@@ -29,6 +29,9 @@ class Qubits(object):
     def __str__(self):
         return 'Qubits(%d)' % self.n
 
+    def normalize(self):
+        print "normalize not implemented yet"
+
     def distribution(self):
         """
         Return the discrete probability distribution for measuring

--- a/qubit.py
+++ b/qubit.py
@@ -30,7 +30,8 @@ class Qubits(object):
         return 'Qubits(%d)' % self.n
 
     def normalize(self):
-        self.state = self.state / np.linalg.norm(self.state)
+        norm = np.sqrt(np.real(np.sum(self.state*np.conjugate(self.state))))
+        self.state = self.state / norm
 
     def distribution(self):
         """

--- a/simulator.py
+++ b/simulator.py
@@ -1,7 +1,7 @@
 
 from gates import Hadamard, Identity
 from qubit import Qubits, Zero, One
-
+from measure import measure
 
 def simple_test():
 
@@ -20,6 +20,10 @@ def simple_test():
 
     print "Non-collapsing peak of probability distribution:"
     print qubits.distribution()
+    print ""
+
+    print "Measure first qubit 3 times"
+    print measure(qubits, 0), measure(qubits, 0), measure(qubits, 0)
     print ""
 
     print ""

--- a/simulator.py
+++ b/simulator.py
@@ -38,6 +38,28 @@ def simple_test():
     print qubits.state
     print ""
 
+    print "Measure first qubit 3 times"
+    print measure(qubits, 0), measure(qubits, 0), measure(qubits, 0)
+    print ""
+
+    print "Measure second qubit 3 times"
+    print measure(qubits, 1), measure(qubits, 1), measure(qubits, 1)
+    print ""
+
+    print "Hadamard and Hadamard on 2 qubits: H*H | (1|00> + 0|01> + 0|10> + 0|11>)"
+    qubits = Qubits(2)
+    (Hadamard * Hadamard) | qubits
+    print ""
+
+    print "Measure first qubit 3 times"
+    print measure(qubits, 0), measure(qubits, 0), measure(qubits, 0)
+    print ""
+
+    print "Measure second qubit 3 times"
+    print measure(qubits, 1), measure(qubits, 1), measure(qubits, 1)
+    print ""
+
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Measure function for qubits. It should be working now. 

    Hadamard on 1 qubit: H | (1|0> + 0|1>)
    [[ 0.70710678+0.0j]
     [ 0.70710678+0.0j]]
    Non-collapsing peak of probability distribution:
    [[ 0.5]
     [ 0.5]]

    Measure first qubit 3 times
    0 0 0


    Hadamard again: H | H | (1|0> + 0|1>)
    [[ 0.70710678+0.0j]
     [ 0.70710678+0.0j]]

    Hadamard and Idenity on 2 qubits: H*I | (1|00> + 0|01> + 0|10> + 0|11>)
    [[ 0.70710678+0.0j]
     [ 0.0+0.0j]
     [ 0.70710678+0.0j]
     [ 0.0+0.0j]]

    Measure first qubit 3 times
    1 1 1

    Measure second qubit 3 times
    0 0 0

    Hadamard and Hadamard on 2 qubits: H*H | (1|00> + 0|01> + 0|10> + 0|11>)

    Measure first qubit 3 times
    0 0 0

    Measure second qubit 3 times
    1 1 1

