### PR TITLE
Add example of swapping with cnots and hadamard.

### DIFF
--- a/examples/swap_by_cnots.qc
+++ b/examples/swap_by_cnots.qc
@@ -1,0 +1,15 @@
+
+register a[0]
+register b[1]
+
+X a
+
+CNOT a b
+H a
+H b
+CNOT a b
+H a
+H b
+CNOT a b
+
+

--- a/examples/swap_by_cnots.qc
+++ b/examples/swap_by_cnots.qc
@@ -2,14 +2,15 @@
 register a[0]
 register b[1]
 
+macro swap a b
+    CNOT a b
+    H a
+    H b
+    CNOT a b
+    H a
+    H b
+    CNOT a b
+
 X a
-
-CNOT a b
-H a
-H b
-CNOT a b
-H a
-H b
-CNOT a b
-
+swap a b
 


### PR DESCRIPTION
Here's an example of how SWAP can be implemented in terms of CNOT and Hadamard gates. First, ```SWAP a b```, where a and b are registers, is equivalent to 
```
CNOT a b
CNOT b a
CNOT a b
```
but this is not possible to run on the simulator since CNOT requires the first qubit to be defined before the second. So we rely on the second equivalence that ```CNOT b a``` is equivalent to
```
H a
H b
CNOT a b
H a
H b
```

@odanielson 