### PR TITLE
Fully working version of groover with three qubits.

### DIFF
--- a/examples/grover.qc
+++ b/examples/grover.qc
@@ -1,0 +1,87 @@
+
+; Groover's algorithm with 3 qubits, reusing the auxillary qubits e_i.
+
+register q0[0]
+register q1[1]
+register q2[2]
+register e1[3]
+register e2[4]
+register e3[5]
+
+include qclib/toffoli.qc
+
+macro XXX a b c
+    X a
+    X b
+    X c
+
+macro HH a b
+    H a
+    H b
+
+macro HHH a b c
+    HH a b
+    H c
+
+macro or a b t1
+    CNOT a t1
+    CNOT b t1
+    toffoli a b t1
+
+macro CCZ a b c
+    H c
+    toffoli a b c
+    H c
+
+macro CZ a b
+    H b
+    CNOT a b
+    H b
+
+macro oracle a b c
+    ; Just CCZ marks 111, flip (and restore) b to mark 101 instead
+    ;msg state before_oracle left 3
+    X b
+    CCZ a b c
+    X b
+
+macro mean_inv a b c t1 t2 t3
+    or a b t1
+    or t1 c t2
+    ; by now t2 is (a OR b OR c)
+    CZ t2 c
+    CZ t2 b
+    CZ t2 a
+    ; if an even number of CZs were applied negations cancelled,
+    ; correct that by first making t3 = true if cancellation occured
+    toffoli c t2 t3
+    toffoli b t2 t3
+    toffoli a t2 t3
+    X t3
+    ; then apply Z once more to apply the correction (unless a=b=c=0 in input)
+    CZ t2 t3
+    ; uncompute temporary qubits
+    X t3
+    toffoli a t2 t3
+    toffoli b t2 t3
+    toffoli c t2 t3
+    or t1 c t2
+    or a b t1
+
+macro grover a b c t1 t2 t3
+    oracle a b c
+    HHH a b c
+    mean_inv a b c t1 t2 t3
+    HHH a b c
+    msg state after_grover left 3
+    msg state after_grover_tmp right 3
+
+
+HHH q0 q1 q2
+
+; For 3 qubits, running two Grover iterations is the (first) maximum
+; for the probability of measuring the marked element.
+grover q0 q1 q2 e1 e2 e3
+grover q0 q1 q2 e1 e2 e3
+
+msg state byend left 3


### PR DESCRIPTION
Fully working Grover's algorithm for three qubits, with uncomputing of ancillary qubits. The `mean_inv` function is the tricky one. To check it, I hacked in a PhaseShift gate acting on three qubits with the hard-coded matrix negating all standard basis vectors except zero. The states in the intermediate steps agree.

Example of a testrun:

```
daniel@shelly:~/code/QuantumProgramming % python qrun.py -n 1 examples/grover.qc
state @after_grover:
P=1.000: 0.18 0.18 0.18 0.18 0.18 0.88 0.18 0.18
Entropy: 0.00
P(|000>) = 0.0312
P(|001>) = 0.0312
P(|010>) = 0.0312
P(|011>) = 0.0312
P(|100>) = 0.0312
P(|101>) = 0.7812
P(|110>) = 0.0312
P(|111>) = 0.0312
state @after_grover_tmp
P=1.000: 1.00 0.00 0 0 0 0 0 0
Entropy: 0.00
P(|000>) = 0.9999
P(|001>) = 0.0000
P(|010>) = 0.0000
P(|011>) = 0.0000
P(|100>) = 0.0000
P(|101>) = 0.0000
P(|110>) = 0.0000
P(|111>) = 0.0000
state @after_grover:
P=1.000: 0.09 0.09 0.09 0.09 0.09 -0.97 0.09 0.09
Entropy: 0.00
P(|000>) = 0.0078
P(|001>) = 0.0078
P(|010>) = 0.0078
P(|011>) = 0.0078
P(|100>) = 0.0078
P(|101>) = 0.9452
P(|110>) = 0.0078
P(|111>) = 0.0078
state @after_grover_tmp
P=1.000: 1.00 -0.00 0 0 0 0 0 0
Entropy: 0.00
P(|000>) = 0.9998
P(|001>) = 0.0000
P(|010>) = 0.0000
P(|011>) = 0.0000
P(|100>) = 0.0000
P(|101>) = 0.0000
P(|110>) = 0.0000
P(|111>) = 0.0000
state @byend:
P=1.000: 0.09 0.09 0.09 0.09 0.09 -0.97 0.09 0.09
Entropy: 0.00
P(|000>) = 0.0078
P(|001>) = 0.0078
P(|010>) = 0.0078
P(|011>) = 0.0078
P(|100>) = 0.0078
P(|101>) = 0.9452
P(|110>) = 0.0078
P(|111>) = 0.0078
Qubit measure: 1, 0, 1, 0, 0, 0
```

@odanielson 