### PR TITLE
Hide output behind require command line switches. Support multiple measures

### DIFF
--- a/drivers/density/simulator.py
+++ b/drivers/density/simulator.py
@@ -42,12 +42,11 @@ def expand_double_gate(gate, i, j, num_qbits):
     return operator
 
 
-def run_gate_array(gate_array):
+def run_gate_array(gate_array, num_measures=1, print_dist=False, print_state=False):
     start = gate_array.pop(0)
     num_qbits = start.n
 
     qubits = Qubits(num_qbits)
-    print "Initial distribution:", qubits.distribution()
 
     for gate in gate_array:
         simulator_gate = gate_array_gate_to_simulator_gate_map[type(gate)]
@@ -62,9 +61,13 @@ def run_gate_array(gate_array):
         else:
             expand_single_gate(simulator_gate, gate.i, num_qbits) | qubits
 
-    print "Final distribution:", qubits.distribution()
-    measurement = [measure(qubits, i) for i in xrange(num_qbits)]
-    print "Qubit measure:", ", ".join((str(q) for q in measurement))
+    if print_dist:
+        print "Final distribution:", qubits.distribution()
+    if print_state:
+        print "Final state:", qubits.state
+    for _ in xrange(num_measures):
+        measurement = [measure(qubits, i, project=False) for i in xrange(num_qbits)]
+        print "Qubit measure:", ", ".join((str(q) for q in measurement))
     return measurement
 
 def simple_test():

--- a/drivers/vector/simulator.py
+++ b/drivers/vector/simulator.py
@@ -42,12 +42,11 @@ def expand_double_gate(gate, i, j, num_qbits):
     return operator
 
 
-def run_gate_array(gate_array):
+def run_gate_array(gate_array, num_measures=1, print_dist=False, print_state=False):
     start = gate_array.pop(0)
     num_qbits = start.n
 
     qubits = Qubits(num_qbits)
-    print "Initial distribution:", qubits.distribution()
 
     for gate in gate_array:
         simulator_gate = gate_array_gate_to_simulator_gate_map[type(gate)]
@@ -62,9 +61,13 @@ def run_gate_array(gate_array):
         else:
             expand_single_gate(simulator_gate, gate.i, num_qbits) | qubits
 
-    print "Final distribution:", qubits.distribution()
-    measurement = [measure(qubits, i) for i in xrange(num_qbits)]
-    print "Qubit measure:", ", ".join((str(q) for q in measurement))
+    if print_dist:
+        print "Final distribution:", qubits.distribution()
+    if print_state:
+        print "Final state:", qubits.state
+    for _ in xrange(num_measures):
+        measurement = [measure(qubits, i, project=False) for i in xrange(num_qbits)]
+        print "Qubit measure:", ", ".join((str(q) for q in measurement))
     return measurement
 
 def simple_test():

--- a/measure.py
+++ b/measure.py
@@ -17,7 +17,7 @@ def trim_probabilities(p):
     return [x + correction/len(trimmed_p) for x in trimmed_p]
 
 
-def measure(qubits, i):
+def measure(qubits, i, project=True):
     """Measure qubit `i` in `qubits` and return 0 or 1. Index `i` from 0."""
     assert i < qubits.n, (
         "qubit %d can not be measured in %d-qubit state" % (i, qubits.n))
@@ -26,9 +26,10 @@ def measure(qubits, i):
     p = trim_probabilities(p)
     index = np.random.choice(np.arange(2**qubits.n), p=p)
     result = get_bit(i, index, qubits.n)
-    projection = ToZero if result == 0 else ToOne
-    transform = (Identity ** i) * projection * (Identity ** (qubits.n-i-1))
-    transform | qubits
-    qubits.normalize()
+    if project:
+        projection = ToZero if result == 0 else ToOne
+        transform = (Identity ** i) * projection * (Identity ** (qubits.n-i-1))
+        transform | qubits
+        qubits.normalize()
 
     return result

--- a/qrun.py
+++ b/qrun.py
@@ -1,4 +1,5 @@
 
+import argparse
 import numpy as np
 import sys
 
@@ -6,26 +7,31 @@ from qcodecompiler import qcompile
 from qsourceparser import parse
 
 
-def run(filename):
-    text = open(filename).read()
-    q_code = parse(text)
+def run(args):
+    text = open(args.filename).read()
+    q_code = parse(text, print_lines=args.print_lines, print_qcode=args.print_qcode)
     gate_array = qcompile(q_code)
-    run_gate_array(gate_array)
+    run_gate_array(gate_array,
+                   num_measures=args.num_measures,
+                   print_dist=args.print_dist,
+                   print_state=args.print_state)
 
 
 if __name__ == "__main__":
-    try:
-        driver = sys.argv[1]
-        filename = sys.argv[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--driver', choices=['vector', 'density'], default='vector')
+    parser.add_argument('--print-lines', help='display line representation', action='store_true', default=False)
+    parser.add_argument('--print-qcode', help='display qcode representation', action='store_true', default=False)
+    parser.add_argument('--print-dist', help='display final distribution', action='store_true', default=False)
+    parser.add_argument('--print-state', help='display final state', action='store_true', default=False)
+    parser.add_argument('-n', '--num-measures', help='measure n times', type=int, default=1)
+    parser.add_argument('filename', help='<source file>')
+    args = parser.parse_args()
 
-    except IndexError:
-        print("Usage: %s [vector|density] <sourcefile>" % sys.argv[0])
-        exit(1)
-
-    if driver == 'vector':
+    if args.driver == 'vector':
         from drivers.vector.simulator import run_gate_array
 
-    elif driver == 'density':
+    elif args.driver == 'density':
         from drivers.density.simulator import run_gate_array
 
     else:
@@ -34,4 +40,4 @@ if __name__ == "__main__":
     np.set_printoptions(precision=2)  # Two decimals
     np.set_printoptions(suppress=True)  # Round small numbers to zero
 
-    run(filename)
+    run(args)

--- a/qsourceparser.py
+++ b/qsourceparser.py
@@ -130,11 +130,10 @@ def parse_qcode(blocks):
     return qc
 
 
-def parse(text, verbose=True):
+def parse(text, verbose=False, print_lines=False, print_qcode=False):
     """Return QCode object from qsource text input."""
-
     lines = parse_lines(text)
-    if verbose:
+    if verbose or print_lines:
         print "\nLine representation:\n"
         print "\n".join([str(line) for line in lines])
 
@@ -152,12 +151,9 @@ def parse(text, verbose=True):
 
     qc = parse_qcode(blocks)
 
-    def print_qcode(qc):
-        print repr(qc)
-
-    if verbose:
+    if verbose or print_qcode:
         print "\nQcode representation\n"
-        print_qcode(qc)
+        print repr(qc)
 
     return qc
 


### PR DESCRIPTION
Get rid of a lot of ugly output, but allow it via command line arguments instead.

Add argument -n <NUMBER> that will measure the distribution n times. This requires that the state is not projected in the measurement step, so some code is added to deal with that.