### PR TITLE
Support right/left parameter to msg directive

### DIFF
--- a/drivers/vector/simulator.py
+++ b/drivers/vector/simulator.py
@@ -5,6 +5,7 @@ from qubit import Qubits, Zero, One
 from measure import measure
 import qmath
 
+
 gate_array_gate_to_simulator_gate_map = {
     gatearray.H: Hadamard,
     gatearray.X: X,
@@ -45,6 +46,19 @@ def expand_double_gate(gate, i, j, num_qbits):
     return operator
 
 
+def handle_msg(label, args, qubits):
+    if len(args) > 0 and args[0] == 'left':
+        print 'state @%s:' % (label)
+        m = int(args[1])
+        qmath.print_subsystem_dist(qubits.state, m, qubits.n - m)
+    elif len(args) > 0 and args[0] == 'right':
+        print 'state @%s' % (label)
+        m = int(args[1])
+        qmath.print_subsystem_dist(qubits.state, qubits.n - m, m, right=True)
+    else:
+        print 'state @%s: %s' % (label, qmath.rough_np_array(qubits.state))
+
+
 def run_gate_array(gate_array, num_measures=1, print_dist=False, print_state=False):
     start = gate_array.pop(0)
     num_qbits = start.n
@@ -53,7 +67,7 @@ def run_gate_array(gate_array, num_measures=1, print_dist=False, print_state=Fal
 
     for gate in gate_array:
         if isinstance(gate, gatearray.MSG):
-            print 'state @%s: %s' % (gate.label, qmath.rough_np_array(qubits.state))
+            handle_msg(gate.label, gate.args, qubits)
             continue
 
         simulator_gate = gate_array_gate_to_simulator_gate_map[type(gate)]

--- a/examples/ghz.qc
+++ b/examples/ghz.qc
@@ -1,0 +1,16 @@
+; Create GHZ state |000> + |111> which generalizes the Bell state.
+
+register q0[0]
+register q1[1]
+register q2[2]
+
+H q0
+CNOT q0 q1
+CNOT q1 q2
+
+msg state all_qubits left 3
+
+; Since the q0 q1 are entangled with q2, this will not be a pure state.
+msg state first_two_qubits left 2
+
+msg state right_qubit right 1


### PR DESCRIPTION
This PR depends on #26 and #27. Only the last commit is new. In the example ghz.qc we can for instance see
```
msg state first_two_qubits left 2
```
This will display information about the two left-most qubits regarded as a subsystem. Since the entire state in this example is entangled, the subsystem will be a mixed state. Each mixed state is displayed as a row beginning with `P=...` to indicate the probability for that pure state in the mixture.  The row continues with a display of the coefficients for each standard basis state. Then follow the probability distribution on the following rows. The output when running the example is:
```
daniel@shelly:~/code/QuantumProgramming % python qrun.py examples/ghz.qc
state @all_qubits:
P=1.000: 0.71 0 0 0 0 0 0 0.71
P(|000>) = 0.5000
P(|001>) = 0.0000
P(|010>) = 0.0000
P(|011>) = 0.0000
P(|100>) = 0.0000
P(|101>) = 0.0000
P(|110>) = 0.0000
P(|111>) = 0.5000
state @first_two_qubits:
P=0.500: 1.00 0 0 0
P=0.500: 0 0 0 1.00
P(|00>) = 0.5000
P(|01>) = 0.0000
P(|10>) = 0.0000
P(|11>) = 0.5000
state @right_qubits
P=0.500: 1.00 0
P=0.500: 0 1.00
P(|0>) = 0.5000
P(|1>) = 0.5000
Qubit measure: 1, 1, 1
```

Note: The density driver will ignore the left/right directive.