### PR TITLE
Add support for printing entropy of subsystem.

### DIFF
--- a/examples/t_test.qc
+++ b/examples/t_test.qc
@@ -1,6 +1,10 @@
 
 register x[0]
+register y[1]
 
 H x
 T x
 H x
+CNOT x y
+
+msg state end left 1

--- a/qmath.py
+++ b/qmath.py
@@ -62,18 +62,29 @@ def basis_density_states(n):
     return [density_operator(bv) for bv in basis_vectors]
 
 
-def print_mixture_summary(rho):
+def print_mixture_summary(rho, evalues, evectors):
     """Summarize pure states making up a mixed state rho by printing
     the probability and the state coefficients. The natural eigenstates
     are used; other mixtures of states may yield the same density
-    operator rho."""
-
-    evalues, evectors = np.linalg.eigh(rho)
+    operator rho. Since eigenvalues and eigenvectors are likley needed
+    outside this function, the are passed as parameter although the
+    are implicit in rho."""
 
     for i, l in enumerate(evalues):
         if np.isclose(l, 0):
             continue
         print 'P=%.3f: %s' % (l, rough_np_array(evectors[:, i]))
+
+
+def entropy(ps):
+    """Return entropy for a list of probabilities p."""
+    def log2(x):
+        if np.isclose(x, 0):
+            return 0  # Convention in definition of entropy
+        else:
+            return np.log2(x)
+
+    return sum(map(lambda p: -p*log2(p), ps))
 
 
 def print_density_summary(rho):
@@ -86,7 +97,11 @@ def print_density_summary(rho):
     assert M == N
     n = int(np.log2(N))
 
-    print_mixture_summary(rho)
+    evalues, evectors = np.linalg.eigh(rho)
+
+    print_mixture_summary(rho, evalues, evectors)
+
+    print 'Entropy: %.2f' % entropy(evalues)
 
     warnings.simplefilter('ignore', np.ComplexWarning)
 


### PR DESCRIPTION
This PR depends on #29.  Add function to print out entropy of a subsystem. An alternative is to add a new msg directive so one could write `msg entropy left 3` to check degree of entanglement for the three left-most qubits. Running the example:
```
daniel@shelly:~/code/QuantumProgramming % python qrun.py examples/t_test.qc
state @end:
P=0.146: 0 1.00
P=0.854: 1.00 0
Entropy: 0.60
P(|0>) = 0.8536
P(|1>) = 0.1464
Qubit measure: 0, 0
```